### PR TITLE
feat: Add exports to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,5 @@
   },
   "exports": {
     "./dist/*.js": "./dist/*.js"
-  },
+  }
 }

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
   "dependencies": {
     "babel-jest": "^29.5.0",
     "jest": "^29.5.0"
-  }
+  },
+  "exports": {
+    "./dist/*.js": "./dist/*.js"
+  },
 }


### PR DESCRIPTION
This PR adds an `exports` object to the package.json file, which enables CDN's such as https://ga.jspm.io/ to parse the package from npm. jspm is the default source for the new Rails v7 importmaps. This PR therefore, enables the package to work in Rails projects, as by default, jspm only exposes the .ts file.