### PR TITLE
fix: This should to the trick for jspm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "3.1.3",
   "description": "Estonian personal ID (isikukood) JavaScript module",
   "main": "src/isikukood.ts",
+  "module": "dist/isikukood.esm.min.js",
+  "standalone": "dist/isikukood.min.js",
   "type": "module",
   "directories": {
     "test": "test"
@@ -41,8 +43,5 @@
   "dependencies": {
     "babel-jest": "^29.5.0",
     "jest": "^29.5.0"
-  },
-  "exports": {
-    "./dist/*.js": "./dist/*.js"
   }
 }


### PR DESCRIPTION
Turns out jspm did not like the exports key. By example of several other packages which work fine in jspm, I have added new keys to the package.json.